### PR TITLE
:lock: fix All output should be run through an escaping function (see…

### DIFF
--- a/src/Service/PostService.php
+++ b/src/Service/PostService.php
@@ -77,7 +77,8 @@ class PostService
 
         if(!$post)
         {
-            throw new \Exception("The post with id {$postId} does not exist.");
+            throw new \Exception("The post with id ".  htmlspecialchars
+                ($postId, ENT_QUOTES, 'UTF-8') . " does not exist.");
         }
 
         return $post;


### PR DESCRIPTION
… the Security sections in the WordPress Developer Handbooks), found '"The post with id {$postId} does not exist."'.