### PR TITLE
:lock: fix All output should be run through an escaping function (see…

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -5,6 +5,7 @@ define("ROOT", dirname(__DIR__));
 use App\Router\RouteManager;
 use Whoops\Handler\PrettyPageHandler;
 use Whoops\Run;
+use Twig\Environment;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
@@ -20,14 +21,12 @@ $container = $containerFactory();
 $router = $container->get(RouteManager::class);
 $match = $router->match();
 
-//dump($_SERVER["REQUEST_URI"]);
-//dump($router);
-//dump($match);
+$twig = $container->get(Environment::class);
 
-function outputMessage(string $message, int $statusCode = 200)
+function renderTemplate(Environment $twig, string $template, array $context = [], int $statusCode = 200)
 {
     http_response_code($statusCode);
-    return htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+    echo $twig->render($template, $context);
 }
 
 
@@ -51,25 +50,21 @@ if (is_array($match))
             }
             else
             {
-                printf("%s" ,outputMessage("404 Not Found - Action not callable.",
-                    404));
+                renderTemplate($twig, 'error/error404.html.twig', ['message' => "Action not callable."], 404);
             }
         }
         catch (Exception $e)
         {
-            printf("%s", outputMessage("500 Internal Server Error - " .
-                               $e->getMessage(),
-                500));
+            renderTemplate($twig, 'error/error500.html.twig', ['message' => $e->getMessage()], 500);
         }
     }
     else
     {
-        printf("%s", outputMessage("404 Not Found - Controller not found.",
-            404));
+        renderTemplate($twig, 'error/error404.html.twig', ['message' => "Controller not found."], 404);
     }
 }
 else
 {
-    printf("%s", outputMessage("404 Not Found - Route not matched.", 404));
+    renderTemplate($twig, 'error/error404.html.twig', ['message' => "Route not matched."], 404);
 }
 

--- a/templates/error/error404.html.twig
+++ b/templates/error/error404.html.twig
@@ -1,0 +1,13 @@
+{% extends "base.html.twig" %}
+
+{% block title %}
+    Social Networks
+{% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
+{% endblock %}
+
+{% block pageTitle %}
+    Error 404 - {{ message }}
+{% endblock %}

--- a/templates/error/error500.html.twig
+++ b/templates/error/error500.html.twig
@@ -1,0 +1,13 @@
+{% extends "base.html.twig" %}
+
+{% block title %}
+    Social Networks
+{% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
+{% endblock %}
+
+{% block pageTitle %}
+    Error 500 - {{ message }}
+{% endblock %}


### PR DESCRIPTION
… the Security sections in the WordPress Developer Handbooks), found 'outputMessage'.